### PR TITLE
Test memoize min time

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 Changelog
 
+Version 2.4.0
+`````````````
+- memoize() now accepts an extra parameter min_time. Cache is set only if function run takes more than min_time.
 
 Version 2.3.1
 `````````````

--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -283,7 +283,11 @@ class Memoizer(object):
 
         return tuple(new_args), kwargs
 
-    def memoize(self, timeout=DEFAULT_TIMEOUT, make_name=None, unless=None, min_time=0):
+    def memoize(self, 
+            timeout=DEFAULT_TIMEOUT, 
+            make_name=None, 
+            unless=None, 
+            min_time=0):
         """
         Use this to cache the result of a function, taking its arguments into
         account in the cache key.

--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -282,7 +282,7 @@ class Memoizer(object):
 
         return tuple(new_args), kwargs
 
-    def memoize(self, timeout=DEFAULT_TIMEOUT, make_name=None, unless=None):
+    def memoize(self, timeout=DEFAULT_TIMEOUT, min_time=0, make_name=None, unless=None):
         """
         Use this to cache the result of a function, taking its arguments into
         account in the cache key.
@@ -361,12 +361,15 @@ class Memoizer(object):
                 # if a cache miss occurs, run the function from scratch
                 # and cache the resulting return value
                 if rv == self.default_cache_value:
+                    start_time = time.time()
                     rv = f(*args, **kwargs)
+                    elapsed_time = time.time() - start_time
                     try:
-                        self.set(
-                            cache_key, rv,
-                            timeout=decorated_function.cache_timeout
-                        )
+                        if elapsed_time > min_time:
+                            self.set(
+                                cache_key, rv,
+                                timeout=decorated_function.cache_timeout
+                            )
                     except Exception:
                         if settings.DEBUG:
                             raise
@@ -386,7 +389,7 @@ class Memoizer(object):
 
             return decorated_function
         return memoize
-
+        
     def delete_memoized(self, f, *args, **kwargs):
         """
         Deletes the specified functions caches, based by given parameters.

--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -8,6 +8,7 @@ import inspect
 import logging
 import sys
 import uuid
+import time
 
 from django.conf import settings
 from django.core.cache import cache as default_cache
@@ -389,7 +390,7 @@ class Memoizer(object):
 
             return decorated_function
         return memoize
-        
+
     def delete_memoized(self, f, *args, **kwargs):
         """
         Deletes the specified functions caches, based by given parameters.

--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -283,7 +283,7 @@ class Memoizer(object):
 
         return tuple(new_args), kwargs
 
-    def memoize(self, timeout=DEFAULT_TIMEOUT, min_time=0, make_name=None, unless=None):
+    def memoize(self, timeout=DEFAULT_TIMEOUT, make_name=None, unless=None, min_time=0):
         """
         Use this to cache the result of a function, taking its arguments into
         account in the cache key.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -726,3 +726,25 @@ class MemoizeTestCase(SimpleTestCase):
 
         # re-enable logger
         logging.disable(logging.NOTSET)
+
+    def test_27_memoize_with_min_time(self):
+        @self.memoizer.memoize(timeout=10, min_time=0.5)
+        def fast_function():
+            return random.randrange(0, 100000)
+
+        @self.memoizer.memoize(timeout=10, min_time=0.5)
+        def slow_function():
+            time.sleep(0.6)
+            return random.randrange(0, 100000)
+
+        # Test fast function
+        result_fast_1 = fast_function()
+        result_fast_2 = fast_function()
+        assert result_fast_1 != result_fast_2, "Fast function should not cache results"
+
+        # Test slow function
+        result_slow_1 = slow_function()
+        result_slow_2 = slow_function()
+        assert result_slow_1 == result_slow_2, "Slow function should cache results"
+
+    

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -728,23 +728,29 @@ class MemoizeTestCase(SimpleTestCase):
         logging.disable(logging.NOTSET)
 
     def test_27_memoize_with_min_time(self):
+        source = (x for x in range(10))
+
         @self.memoizer.memoize(timeout=10, min_time=0.5)
         def fast_function():
-            return random.randrange(0, 100000)
+            return next(source)
 
         @self.memoizer.memoize(timeout=10, min_time=0.5)
         def slow_function():
             time.sleep(0.6)
-            return random.randrange(0, 100000)
+            return next(source)
 
         # Test fast function
         result_fast_1 = fast_function()
         result_fast_2 = fast_function()
-        assert result_fast_1 != result_fast_2, "Fast function should not cache results"
+        assert (
+            result_fast_1 != result_fast_2,
+            "Fast function should not cache results"
+        )
 
         # Test slow function
         result_slow_1 = slow_function()
         result_slow_2 = slow_function()
-        assert result_slow_1 == result_slow_2, "Slow function should cache results"
-
-    
+        assert (
+            result_slow_1 == result_slow_2,
+            "Slow function should cache results"
+        )


### PR DESCRIPTION
This change is related to the ticket: https://trader.atlassian.net/browse/MCNG-380

Unhaggle is storing all unnecessary data in a cache. As a result, I'm altering Unhaggle's caching condition so that we may check our memoize decorator, which determines the time limit and whether or not to cache that query.

Any other application that uses this library won't be affected by this change.

Test Case results

![image](https://github.com/user-attachments/assets/e74899fa-479d-4571-b150-2fba9a9d2d2a)

Results after adding new test case:

![image](https://github.com/user-attachments/assets/0b76bdd7-6f90-474d-9b06-1ee280dee610)
